### PR TITLE
Update Invoke-SlackBot.ps1

### DIFF
--- a/SlackBot/Public/Invoke-SlackBot.ps1
+++ b/SlackBot/Public/Invoke-SlackBot.ps1
@@ -4,10 +4,10 @@ Function Invoke-SlackBot {
     Param(
         [string]$Token = (Import-Clixml "$PSscriptPath\..\Token.xml"),  #So I don't accidentally put it on the internet
         [string]$LogPath = "$Env:USERPROFILE\Logs\SlackBot.log",
-        [string]$WindowsPath = "$PSscriptPath\..\Windows.xml"
+        [string]$PSSlackConfigPath = "$PSscriptPath\..\PSSlackConfig.xml"
     )
     
-    Set-PSSlackConfig -Path $WindowsPath -Token $Token
+    Set-PSSlackConfig -Path $PSSlackConfigPath -Token $Token
     
     #Web API call starts the session and gets a websocket URL to use.
     $RTMSession = Invoke-RestMethod -Uri https://slack.com/api/rtm.start -Body @{token="$Token"}

--- a/SlackBot/Public/Invoke-SlackBot.ps1
+++ b/SlackBot/Public/Invoke-SlackBot.ps1
@@ -2,12 +2,12 @@
 Function Invoke-SlackBot {
     [cmdletbinding()]
     Param(
-        $Token = (Import-Clixml Token.xml),  #So I don't accidentally put it on the internet
-        $LogPath = "$Env:USERPROFILE\Logs\SlackBot.log"
+        [string]$Token = (Import-Clixml "$PSscriptPath\..\Token.xml"),  #So I don't accidentally put it on the internet
+        [string]$LogPath = "$Env:USERPROFILE\Logs\SlackBot.log",
+        [string]$WindowsPath = "$PSscriptPath\..\Windows.xml"
     )
     
-    Import-Module 'PSSlack'
-    Set-PSSlackConfig -Path Windows.xml -Token $Token
+    Set-PSSlackConfig -Path $WindowsPath -Token $Token
     
     #Web API call starts the session and gets a websocket URL to use.
     $RTMSession = Invoke-RestMethod -Uri https://slack.com/api/rtm.start -Body @{token="$Token"}


### PR DESCRIPTION
Required modules need to be specified in the manifest, not imported later upon function execution.

Also, as currently written your file paths were relative to whatever directory you happened to be in at the time of function execution. I've changed the references to default to the root of module folder. I've also parameterized the path to windows.xml