### PR TITLE
Update Invoke-SlackBot.ps1

### DIFF
--- a/SlackBot/Public/Invoke-SlackBot.ps1
+++ b/SlackBot/Public/Invoke-SlackBot.ps1
@@ -51,8 +51,12 @@ Function Invoke-SlackBot {
                                 #A message was sent to the bot
 
                                 # *** Responses go here, for example..***
-                                $words = ($_.text.ToLower() -split " ")
-
+                                $words = "$($_.text)".ToLower()
+                                while ($words -match "  "){
+                                    $words = $words -replace "  "," "
+                                }
+                                $words = $words -split " " | ?{$_}
+                                
                                 Switch ($words){
                                     {@("hey","hello","hi") -contains $_} { Send-SlackMsg -Text 'Hello!' -Channel $RTM.Channel }
                                     {@("bye","cya") -contains $_} { Send-SlackMsg -Text 'Goodbye!' -Channel $RTM.Channel }


### PR DESCRIPTION
Line 54  -  Fixes a bug I found (can't toLower() on a null) which occurs when you use the newly added Start a Thread feature to reply to a comment rather than a channel. This was crashing the bot.

Line 55-58  -  Trims out consecutive spaces, and null array entries created by trailing spaces to give a cleaner word-array for better follow-on behavior.